### PR TITLE
Port chardet to Python 3

### DIFF
--- a/chardet/__init__.py
+++ b/chardet/__init__.py
@@ -15,10 +15,11 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 __version__ = "1.1"
 
 def detect(aBuf):
-    import universaldetector
+    from . import universaldetector
     u = universaldetector.UniversalDetector()
     u.reset()
     u.feed(aBuf)

--- a/chardet/big5prober.py
+++ b/chardet/big5prober.py
@@ -25,10 +25,11 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from mbcharsetprober import MultiByteCharSetProber
-from codingstatemachine import CodingStateMachine
-from chardistribution import Big5DistributionAnalysis
-from mbcssm import Big5SMModel
+from __future__ import absolute_import
+from .mbcharsetprober import MultiByteCharSetProber
+from .codingstatemachine import CodingStateMachine
+from .chardistribution import Big5DistributionAnalysis
+from .mbcssm import Big5SMModel
 
 class Big5Prober(MultiByteCharSetProber):
     def __init__(self):

--- a/chardet/chardistribution.py
+++ b/chardet/chardistribution.py
@@ -39,6 +39,7 @@ ENOUGH_DATA_THRESHOLD = 1024
 SURE_YES = 0.99
 SURE_NO = 0.01
 
+
 class CharDistributionAnalysis:
     def __init__(self):
         self._mCharToFreqOrder = None # Mapping table to get frequency order from char order (get from GetOrder())
@@ -99,14 +100,15 @@ class EUCTWDistributionAnalysis(CharDistributionAnalysis):
         self._mTypicalDistributionRatio = EUCTW_TYPICAL_DISTRIBUTION_RATIO
 
     def get_order(self, aStr):
-        # for euc-TW encoding, we are interested 
+        # for euc-TW encoding, we are interested
         #   first  byte range: 0xc4 -- 0xfe
         #   second byte range: 0xa1 -- 0xfe
         # no validation needed here. State machine has done that
-        if aStr[0] >= '\xC4':
+        if wrap_ord(aStr[0]) >= 0xC4:
             return 94 * (wrap_ord(aStr[0]) - 0xC4) + wrap_ord(aStr[1]) - 0xA1
         else:
             return -1
+
 
 class EUCKRDistributionAnalysis(CharDistributionAnalysis):
     def __init__(self):
@@ -116,14 +118,15 @@ class EUCKRDistributionAnalysis(CharDistributionAnalysis):
         self._mTypicalDistributionRatio = EUCKR_TYPICAL_DISTRIBUTION_RATIO
 
     def get_order(self, aStr):
-        # for euc-KR encoding, we are interested 
+        # for euc-KR encoding, we are interested
         #   first  byte range: 0xb0 -- 0xfe
         #   second byte range: 0xa1 -- 0xfe
         # no validation needed here. State machine has done that
-        if aStr[0] >= '\xB0':
+        if wrap_ord(aStr[0]) >= 0xB0:
             return 94 * (wrap_ord(aStr[0]) - 0xB0) + wrap_ord(aStr[1]) - 0xA1
         else:
-            return -1;
+            return -1
+
 
 class GB2312DistributionAnalysis(CharDistributionAnalysis):
     def __init__(self):
@@ -133,14 +136,15 @@ class GB2312DistributionAnalysis(CharDistributionAnalysis):
         self._mTypicalDistributionRatio = GB2312_TYPICAL_DISTRIBUTION_RATIO
 
     def get_order(self, aStr):
-        # for GB2312 encoding, we are interested 
+        # for GB2312 encoding, we are interested
         #  first  byte range: 0xb0 -- 0xfe
         #  second byte range: 0xa1 -- 0xfe
         # no validation needed here. State machine has done that
-        if (aStr[0] >= '\xB0') and (aStr[1] >= '\xA1'):
+        if wrap_ord(aStr[0]) >= 0xB0 and wrap_ord(aStr[1]) >= 0xA1:
             return 94 * (wrap_ord(aStr[0]) - 0xB0) + wrap_ord(aStr[1]) - 0xA1
         else:
-            return -1;
+            return -1
+
 
 class Big5DistributionAnalysis(CharDistributionAnalysis):
     def __init__(self):
@@ -150,17 +154,20 @@ class Big5DistributionAnalysis(CharDistributionAnalysis):
         self._mTypicalDistributionRatio = BIG5_TYPICAL_DISTRIBUTION_RATIO
 
     def get_order(self, aStr):
-        # for big5 encoding, we are interested 
+        # for big5 encoding, we are interested
         #   first  byte range: 0xa4 -- 0xfe
         #   second byte range: 0x40 -- 0x7e , 0xa1 -- 0xfe
         # no validation needed here. State machine has done that
-        if aStr[0] >= '\xA4':
-            if aStr[1] >= '\xA1':
-                return 157 * (wrap_ord(aStr[0]) - 0xA4) + wrap_ord(aStr[1]) - 0xA1 + 63
+        if wrap_ord(aStr[0]) >= 0xA4:
+            if wrap_ord(aStr[1]) >= 0xA1:
+                return (157 * (wrap_ord(aStr[0]) - 0xA4) + wrap_ord(aStr[1])
+                        - 0xA1 + 63)
             else:
-                return 157 * (wrap_ord(aStr[0]) - 0xA4) + wrap_ord(aStr[1]) - 0x40
+                return (157 * (wrap_ord(aStr[0]) - 0xA4) + wrap_ord(aStr[1])
+                        - 0x40)
         else:
             return -1
+
 
 class SJISDistributionAnalysis(CharDistributionAnalysis):
     def __init__(self):
@@ -170,19 +177,19 @@ class SJISDistributionAnalysis(CharDistributionAnalysis):
         self._mTypicalDistributionRatio = JIS_TYPICAL_DISTRIBUTION_RATIO
 
     def get_order(self, aStr):
-        # for sjis encoding, we are interested 
+        # for sjis encoding, we are interested
         #   first  byte range: 0x81 -- 0x9f , 0xe0 -- 0xfe
         #   second byte range: 0x40 -- 0x7e,  0x81 -- oxfe
         # no validation needed here. State machine has done that
-        if (aStr[0] >= '\x81') and (aStr[0] <= '\x9F'):
+        if wrap_ord(aStr[0]) >= 0x81 and wrap_ord(aStr[0]) <= 0x9F:
             order = 188 * (wrap_ord(aStr[0]) - 0x81)
-        elif (aStr[0] >= '\xE0') and (aStr[0] <= '\xEF'):
+        elif wrap_ord(aStr[0]) >= 0xE0 and wrap_ord(aStr[0]) <= 0xEF:
             order = 188 * (wrap_ord(aStr[0]) - 0xE0 + 31)
         else:
-            return -1;
+            return -1
         order = order + wrap_ord(aStr[1]) - 0x40
-        if aStr[1] > '\x7F':
-            order =- 1
+        if wrap_ord(aStr[1]) > 0x7F:
+            order = -1
         return order
 
 class EUCJPDistributionAnalysis(CharDistributionAnalysis):
@@ -193,11 +200,11 @@ class EUCJPDistributionAnalysis(CharDistributionAnalysis):
         self._mTypicalDistributionRatio = JIS_TYPICAL_DISTRIBUTION_RATIO
 
     def get_order(self, aStr):
-        # for euc-JP encoding, we are interested 
+        # for euc-JP encoding, we are interested
         #   first  byte range: 0xa0 -- 0xfe
         #   second byte range: 0xa1 -- 0xfe
         # no validation needed here. State machine has done that
-        if aStr[0] >= '\xA0':
+        if wrap_ord(aStr[0]) >= 0xA0:
             return 94 * (wrap_ord(aStr[0]) - 0xA1) + wrap_ord(aStr[1]) - 0xa1
         else:
             return -1

--- a/chardet/chardistribution.py
+++ b/chardet/chardistribution.py
@@ -25,7 +25,7 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 from .compat import wrap_ord
 from . import constants

--- a/chardet/chardistribution.py
+++ b/chardet/chardistribution.py
@@ -26,6 +26,8 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
+
+from .compat import wrap_ord
 from . import constants
 from .euctwfreq import EUCTWCharToFreqOrder, EUCTW_TABLE_SIZE, EUCTW_TYPICAL_DISTRIBUTION_RATIO
 from .euckrfreq import EUCKRCharToFreqOrder, EUCKR_TABLE_SIZE, EUCKR_TYPICAL_DISTRIBUTION_RATIO
@@ -102,7 +104,7 @@ class EUCTWDistributionAnalysis(CharDistributionAnalysis):
         #   second byte range: 0xa1 -- 0xfe
         # no validation needed here. State machine has done that
         if aStr[0] >= '\xC4':
-            return 94 * (ord(aStr[0]) - 0xC4) + ord(aStr[1]) - 0xA1
+            return 94 * (wrap_ord(aStr[0]) - 0xC4) + wrap_ord(aStr[1]) - 0xA1
         else:
             return -1
 
@@ -119,7 +121,7 @@ class EUCKRDistributionAnalysis(CharDistributionAnalysis):
         #   second byte range: 0xa1 -- 0xfe
         # no validation needed here. State machine has done that
         if aStr[0] >= '\xB0':
-            return 94 * (ord(aStr[0]) - 0xB0) + ord(aStr[1]) - 0xA1
+            return 94 * (wrap_ord(aStr[0]) - 0xB0) + wrap_ord(aStr[1]) - 0xA1
         else:
             return -1;
 
@@ -136,7 +138,7 @@ class GB2312DistributionAnalysis(CharDistributionAnalysis):
         #  second byte range: 0xa1 -- 0xfe
         # no validation needed here. State machine has done that
         if (aStr[0] >= '\xB0') and (aStr[1] >= '\xA1'):
-            return 94 * (ord(aStr[0]) - 0xB0) + ord(aStr[1]) - 0xA1
+            return 94 * (wrap_ord(aStr[0]) - 0xB0) + wrap_ord(aStr[1]) - 0xA1
         else:
             return -1;
 
@@ -154,9 +156,9 @@ class Big5DistributionAnalysis(CharDistributionAnalysis):
         # no validation needed here. State machine has done that
         if aStr[0] >= '\xA4':
             if aStr[1] >= '\xA1':
-                return 157 * (ord(aStr[0]) - 0xA4) + ord(aStr[1]) - 0xA1 + 63
+                return 157 * (wrap_ord(aStr[0]) - 0xA4) + wrap_ord(aStr[1]) - 0xA1 + 63
             else:
-                return 157 * (ord(aStr[0]) - 0xA4) + ord(aStr[1]) - 0x40
+                return 157 * (wrap_ord(aStr[0]) - 0xA4) + wrap_ord(aStr[1]) - 0x40
         else:
             return -1
 
@@ -173,12 +175,12 @@ class SJISDistributionAnalysis(CharDistributionAnalysis):
         #   second byte range: 0x40 -- 0x7e,  0x81 -- oxfe
         # no validation needed here. State machine has done that
         if (aStr[0] >= '\x81') and (aStr[0] <= '\x9F'):
-            order = 188 * (ord(aStr[0]) - 0x81)
+            order = 188 * (wrap_ord(aStr[0]) - 0x81)
         elif (aStr[0] >= '\xE0') and (aStr[0] <= '\xEF'):
-            order = 188 * (ord(aStr[0]) - 0xE0 + 31)
+            order = 188 * (wrap_ord(aStr[0]) - 0xE0 + 31)
         else:
             return -1;
-        order = order + ord(aStr[1]) - 0x40
+        order = order + wrap_ord(aStr[1]) - 0x40
         if aStr[1] > '\x7F':
             order =- 1
         return order
@@ -196,6 +198,6 @@ class EUCJPDistributionAnalysis(CharDistributionAnalysis):
         #   second byte range: 0xa1 -- 0xfe
         # no validation needed here. State machine has done that
         if aStr[0] >= '\xA0':
-            return 94 * (ord(aStr[0]) - 0xA1) + ord(aStr[1]) - 0xa1
+            return 94 * (wrap_ord(aStr[0]) - 0xA1) + wrap_ord(aStr[1]) - 0xa1
         else:
             return -1

--- a/chardet/chardistribution.py
+++ b/chardet/chardistribution.py
@@ -25,12 +25,13 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-import constants
-from euctwfreq import EUCTWCharToFreqOrder, EUCTW_TABLE_SIZE, EUCTW_TYPICAL_DISTRIBUTION_RATIO
-from euckrfreq import EUCKRCharToFreqOrder, EUCKR_TABLE_SIZE, EUCKR_TYPICAL_DISTRIBUTION_RATIO
-from gb2312freq import GB2312CharToFreqOrder, GB2312_TABLE_SIZE, GB2312_TYPICAL_DISTRIBUTION_RATIO
-from big5freq import Big5CharToFreqOrder, BIG5_TABLE_SIZE, BIG5_TYPICAL_DISTRIBUTION_RATIO
-from jisfreq import JISCharToFreqOrder, JIS_TABLE_SIZE, JIS_TYPICAL_DISTRIBUTION_RATIO
+from __future__ import absolute_import
+from . import constants
+from .euctwfreq import EUCTWCharToFreqOrder, EUCTW_TABLE_SIZE, EUCTW_TYPICAL_DISTRIBUTION_RATIO
+from .euckrfreq import EUCKRCharToFreqOrder, EUCKR_TABLE_SIZE, EUCKR_TYPICAL_DISTRIBUTION_RATIO
+from .gb2312freq import GB2312CharToFreqOrder, GB2312_TABLE_SIZE, GB2312_TYPICAL_DISTRIBUTION_RATIO
+from .big5freq import Big5CharToFreqOrder, BIG5_TABLE_SIZE, BIG5_TYPICAL_DISTRIBUTION_RATIO
+from .jisfreq import JISCharToFreqOrder, JIS_TABLE_SIZE, JIS_TYPICAL_DISTRIBUTION_RATIO
 
 ENOUGH_DATA_THRESHOLD = 1024
 SURE_YES = 0.99

--- a/chardet/chardistribution.py
+++ b/chardet/chardistribution.py
@@ -46,7 +46,7 @@ class CharDistributionAnalysis:
         
     def reset(self):
         """reset analyser, clear any state"""
-        self._mDone = constants.False # If this flag is set to constants.True, detection is done and conclusion has been made
+        self._mDone = False # If this flag is set to True, detection is done and conclusion has been made
         self._mTotalChars = 0 # Total characters encountered
         self._mFreqChars = 0 # The number of characters whose frequency order is less than 512
 

--- a/chardet/charsetgroupprober.py
+++ b/chardet/charsetgroupprober.py
@@ -25,8 +25,9 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 import constants, sys
-from charsetprober import CharSetProber
+from .charsetprober import CharSetProber
 
 class CharSetGroupProber(CharSetProber):
     def __init__(self):

--- a/chardet/charsetgroupprober.py
+++ b/chardet/charsetgroupprober.py
@@ -26,7 +26,9 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-import constants, sys
+import sys
+
+from .constants import eFoundIt, eNotMe, _debug
 from .charsetprober import CharSetProber
 
 class CharSetGroupProber(CharSetProber):
@@ -59,33 +61,33 @@ class CharSetGroupProber(CharSetProber):
             if not prober.active: continue
             st = prober.feed(aBuf)
             if not st: continue
-            if st == constants.eFoundIt:
+            if st == eFoundIt:
                 self._mBestGuessProber = prober
                 return self.get_state()
-            elif st == constants.eNotMe:
+            elif st == eNotMe:
                 prober.active = False
                 self._mActiveNum -= 1
                 if self._mActiveNum <= 0:
-                    self._mState = constants.eNotMe
+                    self._mState = eNotMe
                     return self.get_state()
         return self.get_state()
 
     def get_confidence(self):
         st = self.get_state()
-        if st == constants.eFoundIt:
+        if st == eFoundIt:
             return 0.99
-        elif st == constants.eNotMe:
+        elif st == eNotMe:
             return 0.01
         bestConf = 0.0
         self._mBestGuessProber = None
         for prober in self._mProbers:
             if not prober: continue
             if not prober.active:
-                if constants._debug:
+                if _debug:
                     sys.stderr.write(prober.get_charset_name() + ' not active\n')
                 continue
             cf = prober.get_confidence()
-            if constants._debug:
+            if _debug:
                 sys.stderr.write('%s confidence = %s\n' % (prober.get_charset_name(), cf))
             if bestConf < cf:
                 bestConf = cf

--- a/chardet/charsetgroupprober.py
+++ b/chardet/charsetgroupprober.py
@@ -42,7 +42,7 @@ class CharSetGroupProber(CharSetProber):
         for prober in self._mProbers:
             if prober:
                 prober.reset()
-                prober.active = constants.True
+                prober.active = True
                 self._mActiveNum += 1
         self._mBestGuessProber = None
 
@@ -63,7 +63,7 @@ class CharSetGroupProber(CharSetProber):
                 self._mBestGuessProber = prober
                 return self.get_state()
             elif st == constants.eNotMe:
-                prober.active = constants.False
+                prober.active = False
                 self._mActiveNum -= 1
                 if self._mActiveNum <= 0:
                     self._mState = constants.eNotMe

--- a/chardet/charsetprober.py
+++ b/chardet/charsetprober.py
@@ -26,6 +26,7 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 import constants, re
 
 class CharSetProber:

--- a/chardet/charsetprober.py
+++ b/chardet/charsetprober.py
@@ -52,11 +52,11 @@ class CharSetProber:
         return 0.0
 
     def filter_high_bit_only(self, aBuf):
-        aBuf = re.sub(r'([\x00-\x7F])+', ' ', aBuf)
+        aBuf = re.sub(br'([\x00-\x7F])+', b' ', aBuf)
         return aBuf
     
     def filter_without_english_letters(self, aBuf):
-        aBuf = re.sub(r'([A-Za-z])+', ' ', aBuf)
+        aBuf = re.sub(br'([A-Za-z])+', b' ', aBuf)
         return aBuf
         
     def filter_with_english_letters(self, aBuf):

--- a/chardet/charsetprober.py
+++ b/chardet/charsetprober.py
@@ -27,14 +27,17 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-import constants, re
+import re
+
+from .constants import eDetecting
+
 
 class CharSetProber:
     def __init__(self):
         pass
         
     def reset(self):
-        self._mState = constants.eDetecting
+        self._mState = eDetecting
     
     def get_charset_name(self):
         return None

--- a/chardet/codingstatemachine.py
+++ b/chardet/codingstatemachine.py
@@ -25,7 +25,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from constants import eStart, eError, eItsMe
+from __future__ import absolute_import
+from .constants import eStart, eError, eItsMe
 
 class CodingStateMachine:
     def __init__(self, sm):

--- a/chardet/codingstatemachine.py
+++ b/chardet/codingstatemachine.py
@@ -26,7 +26,10 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
+
 from .constants import eStart, eError, eItsMe
+from .compat import wrap_ord
+
 
 class CodingStateMachine:
     def __init__(self, sm):
@@ -42,7 +45,7 @@ class CodingStateMachine:
         # for each byte we get its class
         # if it is first byte, we also get byte length
         try:
-            byteCls = self._mModel['classTable'][ord(c)]
+            byteCls = self._mModel['classTable'][wrap_ord(c)]
         except IndexError:
             return eError
         if self._mCurrentState == eStart:

--- a/chardet/compat.py
+++ b/chardet/compat.py
@@ -1,0 +1,9 @@
+import sys
+
+PY2 = sys.version_info < (3, 0)
+
+
+def wrap_ord(value):
+    if PY2 or not isinstance(value, int):
+        return ord(value)
+    return value

--- a/chardet/constants.py
+++ b/chardet/constants.py
@@ -26,6 +26,7 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 _debug = 0
 
 eDetecting = 0
@@ -37,11 +38,3 @@ eError = 1
 eItsMe = 2
 
 SHORTCUT_THRESHOLD = 0.95
-
-import __builtin__
-if not hasattr(__builtin__, 'False'):
-    False = 0
-    True = 1
-else:
-    False = __builtin__.False
-    True = __builtin__.True

--- a/chardet/escprober.py
+++ b/chardet/escprober.py
@@ -25,10 +25,11 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 import constants, sys
-from escsm import HZSMModel, ISO2022CNSMModel, ISO2022JPSMModel, ISO2022KRSMModel
-from charsetprober import CharSetProber
-from codingstatemachine import CodingStateMachine
+from .escsm import HZSMModel, ISO2022CNSMModel, ISO2022JPSMModel, ISO2022KRSMModel
+from .charsetprober import CharSetProber
+from .codingstatemachine import CodingStateMachine
 
 class EscCharSetProber(CharSetProber):
     def __init__(self):

--- a/chardet/escprober.py
+++ b/chardet/escprober.py
@@ -26,7 +26,8 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-import constants, sys
+
+from .constants import eError, eNotMe, eFoundIt, eItsMe
 from .escsm import HZSMModel, ISO2022CNSMModel, ISO2022JPSMModel, ISO2022KRSMModel
 from .charsetprober import CharSetProber
 from .codingstatemachine import CodingStateMachine
@@ -66,14 +67,14 @@ class EscCharSetProber(CharSetProber):
                 if not codingSM: continue
                 if not codingSM.active: continue
                 codingState = codingSM.next_state(c)
-                if codingState == constants.eError:
+                if codingState == eError:
                     codingSM.active = False
                     self._mActiveSM -= 1
                     if self._mActiveSM <= 0:
-                        self._mState = constants.eNotMe
+                        self._mState = eNotMe
                         return self.get_state()
-                elif codingState == constants.eItsMe:
-                    self._mState = constants.eFoundIt
+                elif codingState == eItsMe:
+                    self._mState = eFoundIt
                     self._mDetectedCharset = codingSM.get_coding_state_machine()
                     return self.get_state()
                 

--- a/chardet/escprober.py
+++ b/chardet/escprober.py
@@ -46,7 +46,7 @@ class EscCharSetProber(CharSetProber):
         CharSetProber.reset(self)
         for codingSM in self._mCodingSM:
             if not codingSM: continue
-            codingSM.active = constants.True
+            codingSM.active = True
             codingSM.reset()
         self._mActiveSM = len(self._mCodingSM)
         self._mDetectedCharset = None
@@ -67,7 +67,7 @@ class EscCharSetProber(CharSetProber):
                 if not codingSM.active: continue
                 codingState = codingSM.next_state(c)
                 if codingState == constants.eError:
-                    codingSM.active = constants.False
+                    codingSM.active = False
                     self._mActiveSM -= 1
                     if self._mActiveSM <= 0:
                         self._mState = constants.eNotMe

--- a/chardet/escsm.py
+++ b/chardet/escsm.py
@@ -25,7 +25,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from constants import eStart, eError, eItsMe
+from __future__ import absolute_import
+from .constants import eStart, eError, eItsMe
 
 HZ_cls = ( \
 1,0,0,0,0,0,0,0,  # 00 - 07 

--- a/chardet/eucjpprober.py
+++ b/chardet/eucjpprober.py
@@ -26,8 +26,9 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-import constants, sys
-from .constants import eStart, eError, eItsMe
+import sys
+
+from .constants import eStart, eError, eItsMe, _debug, eNotMe, eFoundIt, eDetecting, SHORTCUT_THRESHOLD
 from .mbcharsetprober import MultiByteCharSetProber
 from .codingstatemachine import CodingStateMachine
 from .chardistribution import EUCJPDistributionAnalysis
@@ -55,12 +56,12 @@ class EUCJPProber(MultiByteCharSetProber):
         for i in range(0, aLen):
             codingState = self._mCodingSM.next_state(aBuf[i])
             if codingState == eError:
-                if constants._debug:
+                if _debug:
                     sys.stderr.write(self.get_charset_name() + ' prober hit error at byte ' + str(i) + '\n')
-                self._mState = constants.eNotMe
+                self._mState = eNotMe
                 break
             elif codingState == eItsMe:
-                self._mState = constants.eFoundIt
+                self._mState = eFoundIt
                 break
             elif codingState == eStart:
                 charLen = self._mCodingSM.get_current_charlen()
@@ -74,10 +75,10 @@ class EUCJPProber(MultiByteCharSetProber):
                     
         self._mLastChar[0] = aBuf[aLen - 1]
         
-        if self.get_state() == constants.eDetecting:
+        if self.get_state() == eDetecting:
             if self._mContextAnalyzer.got_enough_data() and \
-                   (self.get_confidence() > constants.SHORTCUT_THRESHOLD):
-                self._mState = constants.eFoundIt
+                   (self.get_confidence() > SHORTCUT_THRESHOLD):
+                self._mState = eFoundIt
 
         return self.get_state()
 

--- a/chardet/eucjpprober.py
+++ b/chardet/eucjpprober.py
@@ -25,13 +25,15 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 import constants, sys
-from constants import eStart, eError, eItsMe
-from mbcharsetprober import MultiByteCharSetProber
-from codingstatemachine import CodingStateMachine
-from chardistribution import EUCJPDistributionAnalysis
-from jpcntx import EUCJPContextAnalysis
-from mbcssm import EUCJPSMModel
+from .constants import eStart, eError, eItsMe
+from .mbcharsetprober import MultiByteCharSetProber
+from .codingstatemachine import CodingStateMachine
+from .chardistribution import EUCJPDistributionAnalysis
+from .jpcntx import EUCJPContextAnalysis
+from .mbcssm import EUCJPSMModel
+from six.moves import range
 
 class EUCJPProber(MultiByteCharSetProber):
     def __init__(self):

--- a/chardet/euckrprober.py
+++ b/chardet/euckrprober.py
@@ -25,10 +25,11 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from mbcharsetprober import MultiByteCharSetProber
-from codingstatemachine import CodingStateMachine
-from chardistribution import EUCKRDistributionAnalysis
-from mbcssm import EUCKRSMModel
+from __future__ import absolute_import
+from .mbcharsetprober import MultiByteCharSetProber
+from .codingstatemachine import CodingStateMachine
+from .chardistribution import EUCKRDistributionAnalysis
+from .mbcssm import EUCKRSMModel
 
 class EUCKRProber(MultiByteCharSetProber):
     def __init__(self):

--- a/chardet/euctwprober.py
+++ b/chardet/euctwprober.py
@@ -25,10 +25,11 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from mbcharsetprober import MultiByteCharSetProber
-from codingstatemachine import CodingStateMachine
-from chardistribution import EUCTWDistributionAnalysis
-from mbcssm import EUCTWSMModel
+from __future__ import absolute_import
+from .mbcharsetprober import MultiByteCharSetProber
+from .codingstatemachine import CodingStateMachine
+from .chardistribution import EUCTWDistributionAnalysis
+from .mbcssm import EUCTWSMModel
 
 class EUCTWProber(MultiByteCharSetProber):
     def __init__(self):

--- a/chardet/gb2312prober.py
+++ b/chardet/gb2312prober.py
@@ -25,10 +25,11 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from mbcharsetprober import MultiByteCharSetProber
-from codingstatemachine import CodingStateMachine
-from chardistribution import GB2312DistributionAnalysis
-from mbcssm import GB2312SMModel
+from __future__ import absolute_import
+from .mbcharsetprober import MultiByteCharSetProber
+from .codingstatemachine import CodingStateMachine
+from .chardistribution import GB2312DistributionAnalysis
+from .mbcssm import GB2312SMModel
 
 class GB2312Prober(MultiByteCharSetProber):
     def __init__(self):

--- a/chardet/hebrewprober.py
+++ b/chardet/hebrewprober.py
@@ -25,8 +25,9 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from charsetprober import CharSetProber
-import constants
+from __future__ import absolute_import
+from .charsetprober import CharSetProber
+from . import constants
 
 # This prober doesn't actually recognize a language or a charset.
 # It is a helper prober for the use of the Hebrew model probers

--- a/chardet/jpcntx.py
+++ b/chardet/jpcntx.py
@@ -189,7 +189,7 @@ class SJISContextAnalysis(JapaneseContextAnalysis):
         # return its order if it is hiragana
         if len(aStr) > 1:
             char_1 = wrap_ord(aStr[1])
-            if ((char == 202) and (0x9F <= char_1 <= 0xF1)):
+            if ((char == 0x82) and (0x9F <= char_1 <= 0xF1)):
                 return char_1 - 0x9F, charLen
 
 

--- a/chardet/jpcntx.py
+++ b/chardet/jpcntx.py
@@ -25,7 +25,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-import constants
+from __future__ import absolute_import
+from . import constants
 
 NUM_OF_CATEGORY = 6
 DONT_KNOW = -1

--- a/chardet/jpcntx.py
+++ b/chardet/jpcntx.py
@@ -130,7 +130,7 @@ class JapaneseContextAnalysis:
         self._mRelSample = [0] * NUM_OF_CATEGORY # category counters, each interger counts sequence in its category
         self._mNeedToSkipCharNum = 0 # if last byte in current buffer is not the last byte of a character, we need to know how many bytes to skip in next buffer
         self._mLastCharOrder = -1 # The order of previous char
-        self._mDone = constants.False # If this flag is set to constants.True, detection is done and conclusion has been made
+        self._mDone = False # If this flag is set to True, detection is done and conclusion has been made
 
     def feed(self, aBuf, aLen):
         if self._mDone: return
@@ -152,7 +152,7 @@ class JapaneseContextAnalysis:
                 if (order != -1) and (self._mLastCharOrder != -1):
                     self._mTotalRel += 1
                     if self._mTotalRel > MAX_REL_THRESHOLD:
-                        self._mDone = constants.True
+                        self._mDone = True
                         break
                     self._mRelSample[jp2CharContext[self._mLastCharOrder][order]] += 1
                 self._mLastCharOrder = order

--- a/chardet/jpcntx.py
+++ b/chardet/jpcntx.py
@@ -25,7 +25,7 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 from .compat import wrap_ord
 from . import constants

--- a/chardet/jpcntx.py
+++ b/chardet/jpcntx.py
@@ -176,9 +176,10 @@ class SJISContextAnalysis(JapaneseContextAnalysis):
     def get_order(self, aStr):
         if not aStr: return -1, 1
         # find out current char's byte length
+        char = wrap_ord(aStr[0])
         try:
-            if ((aStr[0] >= '\x81') and (aStr[0] <= '\x9F')) or \
-               ((aStr[0] >= '\xE0') and (aStr[0] <= '\xFC')):
+            if (((char >= 0x81) and (char <= 0x9F)) or
+               ((char >= 0xE0) and (char <= 0xFC))):
                 charLen = 2
             else:
                 charLen = 1
@@ -187,10 +188,10 @@ class SJISContextAnalysis(JapaneseContextAnalysis):
 
         # return its order if it is hiragana
         if len(aStr) > 1:
-            if (aStr[0] == '\202') and \
-               (aStr[1] >= '\x9F') and \
-               (aStr[1] <= '\xF1'):
-                return wrap_ord(aStr[1]) - 0x9F, charLen
+            char_1 = wrap_ord(aStr[1])
+            if ((char == 202) and (0x9F <= char_1 <= 0xF1)):
+                return char_1 - 0x9F, charLen
+
 
         return -1, charLen
 
@@ -198,11 +199,11 @@ class EUCJPContextAnalysis(JapaneseContextAnalysis):
     def get_order(self, aStr):
         if not aStr: return -1, 1
         # find out current char's byte length
+        char = wrap_ord(aStr[0])
         try:
-            if (aStr[0] == '\x8E') or \
-               ((aStr[0] >= '\xA1') and (aStr[0] <= '\xFE')):
+            if (char == 0x8E) or (0xA1 <= char <= 0xFE):
                 charLen = 2
-            elif aStr[0] == '\x8F':
+            elif aStr[0] == 0x8F:
                 charLen = 3
             else:
                 charLen = 1
@@ -211,9 +212,9 @@ class EUCJPContextAnalysis(JapaneseContextAnalysis):
 
         # return its order if it is hiragana
         if len(aStr) > 1:
-            if (aStr[0] == '\xA4') and \
-               (aStr[1] >= '\xA1') and \
-               (aStr[1] <= '\xF3'):
-                return wrap_ord(aStr[1]) - 0xA1, charLen
+            char_1 = wrap_ord(aStr[1])
+            if (char == 0xA4) and (0xA1 <= char_1 <= 0xF3):
+                return char_1 - 0xA1, charLen
+
 
         return -1, charLen

--- a/chardet/jpcntx.py
+++ b/chardet/jpcntx.py
@@ -26,6 +26,8 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
+
+from .compat import wrap_ord
 from . import constants
 
 NUM_OF_CATEGORY = 6
@@ -188,7 +190,7 @@ class SJISContextAnalysis(JapaneseContextAnalysis):
             if (aStr[0] == '\202') and \
                (aStr[1] >= '\x9F') and \
                (aStr[1] <= '\xF1'):
-                return ord(aStr[1]) - 0x9F, charLen
+                return wrap_ord(aStr[1]) - 0x9F, charLen
 
         return -1, charLen
 
@@ -212,6 +214,6 @@ class EUCJPContextAnalysis(JapaneseContextAnalysis):
             if (aStr[0] == '\xA4') and \
                (aStr[1] >= '\xA1') and \
                (aStr[1] <= '\xF3'):
-                return ord(aStr[1]) - 0xA1, charLen
+                return wrap_ord(aStr[1]) - 0xA1, charLen
 
         return -1, charLen

--- a/chardet/langbulgarianmodel.py
+++ b/chardet/langbulgarianmodel.py
@@ -25,7 +25,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-import constants
+from __future__ import absolute_import
+from . import constants
 
 # 255: Control characters that usually does not exist in any text
 # 254: Carriage/Return

--- a/chardet/langbulgarianmodel.py
+++ b/chardet/langbulgarianmodel.py
@@ -216,7 +216,7 @@ Latin5BulgarianModel = { \
   'charToOrderMap': Latin5_BulgarianCharToOrderMap,
   'precedenceMatrix': BulgarianLangModel,
   'mTypicalPositiveRatio': 0.969392,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "ISO-8859-5"
 }
 
@@ -224,6 +224,6 @@ Win1251BulgarianModel = { \
   'charToOrderMap': win1251BulgarianCharToOrderMap,
   'precedenceMatrix': BulgarianLangModel,
   'mTypicalPositiveRatio': 0.969392,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "windows-1251"
 }

--- a/chardet/langcyrillicmodel.py
+++ b/chardet/langcyrillicmodel.py
@@ -25,7 +25,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-import constants
+from __future__ import absolute_import
+from . import constants
 
 # KOI8-R language model
 # Character Mapping Table:

--- a/chardet/langcyrillicmodel.py
+++ b/chardet/langcyrillicmodel.py
@@ -285,7 +285,7 @@ Koi8rModel = { \
   'charToOrderMap': KOI8R_CharToOrderMap,
   'precedenceMatrix': RussianLangModel,
   'mTypicalPositiveRatio': 0.976601,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "KOI8-R"
 }
 
@@ -293,7 +293,7 @@ Win1251CyrillicModel = { \
   'charToOrderMap': win1251_CharToOrderMap,
   'precedenceMatrix': RussianLangModel,
   'mTypicalPositiveRatio': 0.976601,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "windows-1251"
 }
 
@@ -301,7 +301,7 @@ Latin5CyrillicModel = { \
   'charToOrderMap': latin5_CharToOrderMap,
   'precedenceMatrix': RussianLangModel,
   'mTypicalPositiveRatio': 0.976601,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "ISO-8859-5"
 }
 
@@ -309,7 +309,7 @@ MacCyrillicModel = { \
   'charToOrderMap': macCyrillic_CharToOrderMap,
   'precedenceMatrix': RussianLangModel,
   'mTypicalPositiveRatio': 0.976601,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "MacCyrillic"
 };
 
@@ -317,7 +317,7 @@ Ibm866Model = { \
   'charToOrderMap': IBM866_CharToOrderMap,
   'precedenceMatrix': RussianLangModel,
   'mTypicalPositiveRatio': 0.976601,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "IBM866"
 }
 
@@ -325,6 +325,6 @@ Ibm855Model = { \
   'charToOrderMap': IBM855_CharToOrderMap,
   'precedenceMatrix': RussianLangModel,
   'mTypicalPositiveRatio': 0.976601,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "IBM855"
 }

--- a/chardet/langgreekmodel.py
+++ b/chardet/langgreekmodel.py
@@ -25,7 +25,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-import constants
+from __future__ import absolute_import
+from . import constants
 
 # 255: Control characters that usually does not exist in any text
 # 254: Carriage/Return

--- a/chardet/langgreekmodel.py
+++ b/chardet/langgreekmodel.py
@@ -213,7 +213,7 @@ Latin7GreekModel = { \
   'charToOrderMap': Latin7_CharToOrderMap,
   'precedenceMatrix': GreekLangModel,
   'mTypicalPositiveRatio': 0.982851,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "ISO-8859-7"
 }
 
@@ -221,6 +221,6 @@ Win1253GreekModel = { \
   'charToOrderMap': win1253_CharToOrderMap,
   'precedenceMatrix': GreekLangModel,
   'mTypicalPositiveRatio': 0.982851,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "windows-1253"
 }

--- a/chardet/langhebrewmodel.py
+++ b/chardet/langhebrewmodel.py
@@ -27,7 +27,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-import constants
+from __future__ import absolute_import
+from . import constants
 
 # 255: Control characters that usually does not exist in any text
 # 254: Carriage/Return

--- a/chardet/langhebrewmodel.py
+++ b/chardet/langhebrewmodel.py
@@ -28,7 +28,6 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-from . import constants
 
 # 255: Control characters that usually does not exist in any text
 # 254: Carriage/Return

--- a/chardet/langhebrewmodel.py
+++ b/chardet/langhebrewmodel.py
@@ -197,6 +197,6 @@ Win1255HebrewModel = { \
   'charToOrderMap': win1255_CharToOrderMap,
   'precedenceMatrix': HebrewLangModel,
   'mTypicalPositiveRatio': 0.984004,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "windows-1255"
 }

--- a/chardet/langhungarianmodel.py
+++ b/chardet/langhungarianmodel.py
@@ -25,7 +25,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-import constants
+from __future__ import absolute_import
+from . import constants
 
 # 255: Control characters that usually does not exist in any text
 # 254: Carriage/Return

--- a/chardet/langhungarianmodel.py
+++ b/chardet/langhungarianmodel.py
@@ -213,7 +213,7 @@ Latin2HungarianModel = { \
   'charToOrderMap': Latin2_HungarianCharToOrderMap,
   'precedenceMatrix': HungarianLangModel,
   'mTypicalPositiveRatio': 0.947368,
-  'keepEnglishLetter': constants.True,
+  'keepEnglishLetter': True,
   'charsetName': "ISO-8859-2"
 }
 
@@ -221,6 +221,6 @@ Win1250HungarianModel = { \
   'charToOrderMap': win1250HungarianCharToOrderMap,
   'precedenceMatrix': HungarianLangModel,
   'mTypicalPositiveRatio': 0.947368,
-  'keepEnglishLetter': constants.True,
+  'keepEnglishLetter': True,
   'charsetName': "windows-1250"
 }

--- a/chardet/langthaimodel.py
+++ b/chardet/langthaimodel.py
@@ -25,7 +25,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-import constants
+from __future__ import absolute_import
+from . import constants
 
 # 255: Control characters that usually does not exist in any text
 # 254: Carriage/Return

--- a/chardet/langthaimodel.py
+++ b/chardet/langthaimodel.py
@@ -196,6 +196,6 @@ TIS620ThaiModel = { \
   'charToOrderMap': TIS620CharToOrderMap,
   'precedenceMatrix': ThaiLangModel,
   'mTypicalPositiveRatio': 0.926386,
-  'keepEnglishLetter': constants.False,
+  'keepEnglishLetter': False,
   'charsetName': "TIS-620"
 }

--- a/chardet/latin1prober.py
+++ b/chardet/latin1prober.py
@@ -26,7 +26,7 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import operator
 from functools import reduce

--- a/chardet/latin1prober.py
+++ b/chardet/latin1prober.py
@@ -27,10 +27,13 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-from .charsetprober import CharSetProber
-from . import constants
+
 import operator
 from functools import reduce
+
+from .compat import wrap_ord
+from .charsetprober import CharSetProber
+from . import constants
 
 FREQ_CAT_NUM = 4
 
@@ -112,7 +115,7 @@ class Latin1Prober(CharSetProber):
         aBuf = self.filter_with_english_letters(aBuf)
         for c in aBuf:
             try:
-                charClass = Latin1_CharToClass[ord(c)]
+                charClass = Latin1_CharToClass[wrap_ord(c)]
             except IndexError:
                 return constants.eError
             freq = Latin1ClassModel[(self._mLastCharClass * CLASS_NUM) + charClass]

--- a/chardet/latin1prober.py
+++ b/chardet/latin1prober.py
@@ -26,9 +26,11 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from charsetprober import CharSetProber
-import constants
+from __future__ import absolute_import
+from .charsetprober import CharSetProber
+from . import constants
 import operator
+from functools import reduce
 
 FREQ_CAT_NUM = 4
 

--- a/chardet/mbcharsetprober.py
+++ b/chardet/mbcharsetprober.py
@@ -28,8 +28,9 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-import constants, sys
-from .constants import eStart, eError, eItsMe
+import sys
+
+from .constants import eStart, eError, eItsMe, _debug, eNotMe, eDetecting, SHORTCUT_THRESHOLD, eFoundIt
 from .charsetprober import CharSetProber
 from six.moves import range
 
@@ -56,12 +57,12 @@ class MultiByteCharSetProber(CharSetProber):
         for i in range(0, aLen):
             codingState = self._mCodingSM.next_state(aBuf[i])
             if codingState == eError:
-                if constants._debug:
+                if _debug:
                     sys.stderr.write(self.get_charset_name() + ' prober hit error at byte ' + str(i) + '\n')
-                self._mState = constants.eNotMe
+                self._mState = eNotMe
                 break
             elif codingState == eItsMe:
-                self._mState = constants.eFoundIt
+                self._mState = eFoundIt
                 break
             elif codingState == eStart:
                 charLen = self._mCodingSM.get_current_charlen()
@@ -73,10 +74,10 @@ class MultiByteCharSetProber(CharSetProber):
                     
         self._mLastChar[0] = aBuf[aLen - 1]
         
-        if self.get_state() == constants.eDetecting:
+        if self.get_state() == eDetecting:
             if self._mDistributionAnalyzer.got_enough_data() and \
-               (self.get_confidence() > constants.SHORTCUT_THRESHOLD):
-                self._mState = constants.eFoundIt
+               (self.get_confidence() > SHORTCUT_THRESHOLD):
+                self._mState = eFoundIt
 
         return self.get_state()
 

--- a/chardet/mbcharsetprober.py
+++ b/chardet/mbcharsetprober.py
@@ -27,9 +27,11 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 import constants, sys
-from constants import eStart, eError, eItsMe
-from charsetprober import CharSetProber
+from .constants import eStart, eError, eItsMe
+from .charsetprober import CharSetProber
+from six.moves import range
 
 class MultiByteCharSetProber(CharSetProber):
     def __init__(self):

--- a/chardet/mbcsgroupprober.py
+++ b/chardet/mbcsgroupprober.py
@@ -27,14 +27,15 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from charsetgroupprober import CharSetGroupProber
-from utf8prober import UTF8Prober
-from sjisprober import SJISProber
-from eucjpprober import EUCJPProber
-from gb2312prober import GB2312Prober
-from euckrprober import EUCKRProber
-from big5prober import Big5Prober
-from euctwprober import EUCTWProber
+from __future__ import absolute_import
+from .charsetgroupprober import CharSetGroupProber
+from .utf8prober import UTF8Prober
+from .sjisprober import SJISProber
+from .eucjpprober import EUCJPProber
+from .gb2312prober import GB2312Prober
+from .euckrprober import EUCKRProber
+from .big5prober import Big5Prober
+from .euctwprober import EUCTWProber
 
 class MBCSGroupProber(CharSetGroupProber):
     def __init__(self):

--- a/chardet/mbcssm.py
+++ b/chardet/mbcssm.py
@@ -25,7 +25,8 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from constants import eStart, eError, eItsMe
+from __future__ import absolute_import
+from .constants import eStart, eError, eItsMe
 
 # BIG5 
 

--- a/chardet/sbcharsetprober.py
+++ b/chardet/sbcharsetprober.py
@@ -29,6 +29,7 @@
 from __future__ import absolute_import
 import sys
 
+from .compat import wrap_ord
 from .constants import eError, eDetecting, _debug, eFoundIt, eNotMe
 from .charsetprober import CharSetProber
 
@@ -71,7 +72,7 @@ class SingleByteCharSetProber(CharSetProber):
             return self.get_state()
         for c in aBuf:
             try:
-                order = self._mModel['charToOrderMap'][ord(c)]
+                order = self._mModel['charToOrderMap'][wrap_ord(c)]
             except IndexError:
                 return eError
             if order < SYMBOL_CAT_ORDER:

--- a/chardet/sbcharsetprober.py
+++ b/chardet/sbcharsetprober.py
@@ -26,7 +26,7 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 import sys
 
 from .compat import wrap_ord

--- a/chardet/sbcharsetprober.py
+++ b/chardet/sbcharsetprober.py
@@ -26,8 +26,9 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 import constants, sys
-from charsetprober import CharSetProber
+from .charsetprober import CharSetProber
 
 SAMPLE_SIZE = 64
 SB_ENOUGH_REL_THRESHOLD = 1024

--- a/chardet/sbcharsetprober.py
+++ b/chardet/sbcharsetprober.py
@@ -40,7 +40,7 @@ POSITIVE_CAT = NUMBER_OF_SEQ_CAT - 1
 #NEGATIVE_CAT = 0
 
 class SingleByteCharSetProber(CharSetProber):
-    def __init__(self, model, reversed=constants.False, nameProber=None):
+    def __init__(self, model, reversed=False, nameProber=None):
         CharSetProber.__init__(self)
         self._mModel = model
         self._mReversed = reversed # TRUE if we need to reverse every pair in the model lookup

--- a/chardet/sbcharsetprober.py
+++ b/chardet/sbcharsetprober.py
@@ -27,7 +27,9 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-import constants, sys
+import sys
+
+from .constants import eError, eDetecting, _debug, eFoundIt, eNotMe
 from .charsetprober import CharSetProber
 
 SAMPLE_SIZE = 64
@@ -71,7 +73,7 @@ class SingleByteCharSetProber(CharSetProber):
             try:
                 order = self._mModel['charToOrderMap'][ord(c)]
             except IndexError:
-                return constants.eError
+                return eError
             if order < SYMBOL_CAT_ORDER:
                 self._mTotalChar += 1
             if order < SAMPLE_SIZE:
@@ -84,17 +86,17 @@ class SingleByteCharSetProber(CharSetProber):
                         self._mSeqCounters[self._mModel['precedenceMatrix'][(order * SAMPLE_SIZE) + self._mLastOrder]] += 1
             self._mLastOrder = order
 
-        if self.get_state() == constants.eDetecting:
+        if self.get_state() == eDetecting:
             if self._mTotalSeqs > SB_ENOUGH_REL_THRESHOLD:
                 cf = self.get_confidence()
                 if cf > POSITIVE_SHORTCUT_THRESHOLD:
-                    if constants._debug:
+                    if _debug:
                         sys.stderr.write('%s confidence = %s, we have a winner\n' % (self._mModel['charsetName'], cf))
-                    self._mState = constants.eFoundIt
+                    self._mState = eFoundIt
                 elif cf < NEGATIVE_SHORTCUT_THRESHOLD:
-                    if constants._debug:
+                    if _debug:
                         sys.stderr.write('%s confidence = %s, below negative shortcut threshhold %s\n' % (self._mModel['charsetName'], cf, NEGATIVE_SHORTCUT_THRESHOLD))
-                    self._mState = constants.eNotMe
+                    self._mState = eNotMe
 
         return self.get_state()
 

--- a/chardet/sbcsgroupprober.py
+++ b/chardet/sbcsgroupprober.py
@@ -26,16 +26,17 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 import constants, sys
-from charsetgroupprober import CharSetGroupProber
-from sbcharsetprober import SingleByteCharSetProber
-from langcyrillicmodel import Win1251CyrillicModel, Koi8rModel, Latin5CyrillicModel, MacCyrillicModel, Ibm866Model, Ibm855Model
-from langgreekmodel import Latin7GreekModel, Win1253GreekModel
-from langbulgarianmodel import Latin5BulgarianModel, Win1251BulgarianModel
-from langhungarianmodel import Latin2HungarianModel, Win1250HungarianModel
-from langthaimodel import TIS620ThaiModel
-from langhebrewmodel import Win1255HebrewModel
-from hebrewprober import HebrewProber
+from .charsetgroupprober import CharSetGroupProber
+from .sbcharsetprober import SingleByteCharSetProber
+from .langcyrillicmodel import Win1251CyrillicModel, Koi8rModel, Latin5CyrillicModel, MacCyrillicModel, Ibm866Model, Ibm855Model
+from .langgreekmodel import Latin7GreekModel, Win1253GreekModel
+from .langbulgarianmodel import Latin5BulgarianModel, Win1251BulgarianModel
+from .langhungarianmodel import Latin2HungarianModel, Win1250HungarianModel
+from .langthaimodel import TIS620ThaiModel
+from .langhebrewmodel import Win1255HebrewModel
+from .hebrewprober import HebrewProber
 
 class SBCSGroupProber(CharSetGroupProber):
     def __init__(self):

--- a/chardet/sbcsgroupprober.py
+++ b/chardet/sbcsgroupprober.py
@@ -27,7 +27,8 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-import constants, sys
+import sys
+
 from .charsetgroupprober import CharSetGroupProber
 from .sbcharsetprober import SingleByteCharSetProber
 from .langcyrillicmodel import Win1251CyrillicModel, Koi8rModel, Latin5CyrillicModel, MacCyrillicModel, Ibm866Model, Ibm855Model

--- a/chardet/sbcsgroupprober.py
+++ b/chardet/sbcsgroupprober.py
@@ -57,8 +57,8 @@ class SBCSGroupProber(CharSetGroupProber):
             SingleByteCharSetProber(TIS620ThaiModel),
             ]
         hebrewProber = HebrewProber()
-        logicalHebrewProber = SingleByteCharSetProber(Win1255HebrewModel, constants.False, hebrewProber)
-        visualHebrewProber = SingleByteCharSetProber(Win1255HebrewModel, constants.True, hebrewProber)
+        logicalHebrewProber = SingleByteCharSetProber(Win1255HebrewModel, False, hebrewProber)
+        visualHebrewProber = SingleByteCharSetProber(Win1255HebrewModel, True, hebrewProber)
         hebrewProber.set_model_probers(logicalHebrewProber, visualHebrewProber)
         self._mProbers.extend([hebrewProber, logicalHebrewProber, visualHebrewProber])
 

--- a/chardet/sbcsgroupprober.py
+++ b/chardet/sbcsgroupprober.py
@@ -53,8 +53,10 @@ class SBCSGroupProber(CharSetGroupProber):
             SingleByteCharSetProber(Win1253GreekModel),
             SingleByteCharSetProber(Latin5BulgarianModel),
             SingleByteCharSetProber(Win1251BulgarianModel),
-            SingleByteCharSetProber(Latin2HungarianModel),
-            SingleByteCharSetProber(Win1250HungarianModel),
+            # TODO: Restore Hungarian encodings (iso-8859-2 and windows-1250)
+            #       after we retrain model.
+            # SingleByteCharSetProber(Latin2HungarianModel),
+            # SingleByteCharSetProber(Win1250HungarianModel),
             SingleByteCharSetProber(TIS620ThaiModel),
             ]
         hebrewProber = HebrewProber()

--- a/chardet/sjisprober.py
+++ b/chardet/sjisprober.py
@@ -26,13 +26,14 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
+import sys
+
 from .mbcharsetprober import MultiByteCharSetProber
 from .codingstatemachine import CodingStateMachine
 from .chardistribution import SJISDistributionAnalysis
 from .jpcntx import SJISContextAnalysis
 from .mbcssm import SJISSMModel
-import constants, sys
-from .constants import eStart, eError, eItsMe
+from .constants import eStart, eError, eItsMe, _debug, eNotMe, eFoundIt, eDetecting, SHORTCUT_THRESHOLD
 from six.moves import range
 
 class SJISProber(MultiByteCharSetProber):
@@ -55,12 +56,12 @@ class SJISProber(MultiByteCharSetProber):
         for i in range(0, aLen):
             codingState = self._mCodingSM.next_state(aBuf[i])
             if codingState == eError:
-                if constants._debug:
+                if _debug:
                     sys.stderr.write(self.get_charset_name() + ' prober hit error at byte ' + str(i) + '\n')
-                self._mState = constants.eNotMe
+                self._mState = eNotMe
                 break
             elif codingState == eItsMe:
-                self._mState = constants.eFoundIt
+                self._mState = eFoundIt
                 break
             elif codingState == eStart:
                 charLen = self._mCodingSM.get_current_charlen()
@@ -74,10 +75,10 @@ class SJISProber(MultiByteCharSetProber):
 
         self._mLastChar[0] = aBuf[aLen - 1]
 
-        if self.get_state() == constants.eDetecting:
+        if self.get_state() == eDetecting:
             if self._mContextAnalyzer.got_enough_data() and \
-                   (self.get_confidence() > constants.SHORTCUT_THRESHOLD):
-                self._mState = constants.eFoundIt
+                   (self.get_confidence() > SHORTCUT_THRESHOLD):
+                self._mState = eFoundIt
 
         return self.get_state()
 

--- a/chardet/sjisprober.py
+++ b/chardet/sjisprober.py
@@ -25,13 +25,15 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-from mbcharsetprober import MultiByteCharSetProber
-from codingstatemachine import CodingStateMachine
-from chardistribution import SJISDistributionAnalysis
-from jpcntx import SJISContextAnalysis
-from mbcssm import SJISSMModel
+from __future__ import absolute_import
+from .mbcharsetprober import MultiByteCharSetProber
+from .codingstatemachine import CodingStateMachine
+from .chardistribution import SJISDistributionAnalysis
+from .jpcntx import SJISContextAnalysis
+from .mbcssm import SJISSMModel
 import constants, sys
-from constants import eStart, eError, eItsMe
+from .constants import eStart, eError, eItsMe
+from six.moves import range
 
 class SJISProber(MultiByteCharSetProber):
     def __init__(self):

--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -46,8 +46,8 @@ eHighbyte = 2
 
 class UniversalDetector:
     def __init__(self):
-        self._highBitDetector = re.compile(r'[\x80-\xFF]')
-        self._escDetector = re.compile(r'(\033|~{)')
+        self._highBitDetector = re.compile(br'[\x80-\xFF]')
+        self._escDetector = re.compile(br'(\033|~{)')
         self._mEscCharSetProber = None
         self._mCharSetProbers = []
         self.reset()

--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -52,9 +52,9 @@ class UniversalDetector:
 
     def reset(self):
         self.result = {'encoding': None, 'confidence': 0.0}
-        self.done = constants.False
-        self._mStart = constants.True
-        self._mGotData = constants.False
+        self.done = False
+        self._mStart = True
+        self._mGotData = False
         self._mInputState = ePureAscii
         self._mLastChar = ''
         if self._mEscCharSetProber:
@@ -92,9 +92,9 @@ class UniversalDetector:
                     self.result = result
                     break
 
-        self._mGotData = constants.True
+        self._mGotData = True
         if self.result['encoding'] and (self.result['confidence'] > 0.0):
-            self.done = constants.True
+            self.done = True
             return
 
         if self._mInputState == ePureAscii:
@@ -111,7 +111,7 @@ class UniversalDetector:
             if self._mEscCharSetProber.feed(aBuf) == constants.eFoundIt:
                 self.result = {'encoding': self._mEscCharSetProber.get_charset_name(),
                                'confidence': self._mEscCharSetProber.get_confidence()}
-                self.done = constants.True
+                self.done = True
         elif self._mInputState == eHighbyte:
             if not self._mCharSetProbers:
                 self._mCharSetProbers = [MBCSGroupProber(), SBCSGroupProber(), Latin1Prober()]
@@ -120,7 +120,7 @@ class UniversalDetector:
                     if prober.feed(aBuf) == constants.eFoundIt:
                         self.result = {'encoding': prober.get_charset_name(),
                                        'confidence': prober.get_confidence()}
-                        self.done = constants.True
+                        self.done = True
                         break
                 except (UnicodeDecodeError, UnicodeEncodeError) as e:
                     logger.exception(e)
@@ -131,7 +131,7 @@ class UniversalDetector:
             if constants._debug:
                 sys.stderr.write('no data received!\n')
             return
-        self.done = constants.True
+        self.done = True
 
         if self._mInputState == ePureAscii:
             self.result = {'encoding': 'ascii', 'confidence': 1.0}

--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -69,19 +69,19 @@ class UniversalDetector:
 
         charmap = (
             # EF BB BF  UTF-8 with BOM
-            ('\xEF\xBB\xBF', {'encoding': "UTF-8", 'confidence': 1.0}),
+            (b'\xEF\xBB\xBF', {'encoding': "UTF-8", 'confidence': 1.0}),
             # FF FE 00 00  UTF-32, little-endian BOM
-            ('\xFF\xFE\x00\x00', {'encoding': "UTF-32LE", 'confidence': 1.0}),
+            (b'\xFF\xFE\x00\x00', {'encoding': "UTF-32LE", 'confidence': 1.0}),
             # 00 00 FE FF  UTF-32, big-endian BOM
-            ('\x00\x00\xFE\xFF', {'encoding': "UTF-32BE", 'confidence': 1.0}),
+            (b'\x00\x00\xFE\xFF', {'encoding': "UTF-32BE", 'confidence': 1.0}),
             # FE FF 00 00  UCS-4, unusual octet order BOM (3412)
-            (u'\xFE\xFF\x00\x00', {'encoding': "X-ISO-10646-UCS-4-3412", 'confidence': 1.0}),
+            (b'\xFE\xFF\x00\x00', {'encoding': "X-ISO-10646-UCS-4-3412", 'confidence': 1.0}),
             # 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
-            (u'\x00\x00\xFF\xFE', {'encoding': "X-ISO-10646-UCS-4-2143", 'confidence': 1.0}),
+            (b'\x00\x00\xFF\xFE', {'encoding': "X-ISO-10646-UCS-4-2143", 'confidence': 1.0}),
             # FF FE  UTF-16, little endian BOM
-            ('\xFF\xFE', {'encoding': "UTF-16LE", 'confidence': 1.0}),
+            (b'\xFF\xFE', {'encoding': "UTF-16LE", 'confidence': 1.0}),
             # FE FF  UTF-16, big endian BOM
-            ('\xFE\xFF', {'encoding': "UTF-16BE", 'confidence': 1.0}),
+            (b'\xFE\xFF', {'encoding': "UTF-16BE", 'confidence': 1.0}),
         )
 
         aLen = len(aBuf)

--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -58,7 +58,7 @@ class UniversalDetector:
         self._mStart = True
         self._mGotData = False
         self._mInputState = ePureAscii
-        self._mLastChar = ''
+        self._mLastChar = b''
         if self._mEscCharSetProber:
             self._mEscCharSetProber.reset()
         for prober in self._mCharSetProbers:
@@ -105,7 +105,7 @@ class UniversalDetector:
             elif (self._mInputState == ePureAscii) and self._escDetector.search(self._mLastChar + aBuf):
                 self._mInputState = eEscAscii
 
-        self._mLastChar = aBuf[-1]
+        self._mLastChar = aBuf[-1:]
 
         if self._mInputState == eEscAscii:
             if not self._mEscCharSetProber:

--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -26,11 +26,12 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 import constants, sys
-from latin1prober import Latin1Prober # windows-1252
-from mbcsgroupprober import MBCSGroupProber # multi-byte character sets
-from sbcsgroupprober import SBCSGroupProber # single-byte character sets
-from escprober import EscCharSetProber # ISO-2122, etc.
+from .latin1prober import Latin1Prober # windows-1252
+from .mbcsgroupprober import MBCSGroupProber # multi-byte character sets
+from .sbcsgroupprober import SBCSGroupProber # single-byte character sets
+from .escprober import EscCharSetProber # ISO-2122, etc.
 import re
 import logging
 
@@ -121,7 +122,7 @@ class UniversalDetector:
                                        'confidence': prober.get_confidence()}
                         self.done = constants.True
                         break
-                except (UnicodeDecodeError, UnicodeEncodeError), e:
+                except (UnicodeDecodeError, UnicodeEncodeError) as e:
                     logger.exception(e)
 
     def close(self):

--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -27,13 +27,15 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-import constants, sys
+import sys
+import re
+import logging
+
+from .constants import eFoundIt, _debug
 from .latin1prober import Latin1Prober # windows-1252
 from .mbcsgroupprober import MBCSGroupProber # multi-byte character sets
 from .sbcsgroupprober import SBCSGroupProber # single-byte character sets
 from .escprober import EscCharSetProber # ISO-2122, etc.
-import re
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +110,7 @@ class UniversalDetector:
         if self._mInputState == eEscAscii:
             if not self._mEscCharSetProber:
                 self._mEscCharSetProber = EscCharSetProber()
-            if self._mEscCharSetProber.feed(aBuf) == constants.eFoundIt:
+            if self._mEscCharSetProber.feed(aBuf) == eFoundIt:
                 self.result = {'encoding': self._mEscCharSetProber.get_charset_name(),
                                'confidence': self._mEscCharSetProber.get_confidence()}
                 self.done = True
@@ -117,7 +119,7 @@ class UniversalDetector:
                 self._mCharSetProbers = [MBCSGroupProber(), SBCSGroupProber(), Latin1Prober()]
             for prober in self._mCharSetProbers:
                 try:
-                    if prober.feed(aBuf) == constants.eFoundIt:
+                    if prober.feed(aBuf) == eFoundIt:
                         self.result = {'encoding': prober.get_charset_name(),
                                        'confidence': prober.get_confidence()}
                         self.done = True
@@ -128,7 +130,7 @@ class UniversalDetector:
     def close(self):
         if self.done: return
         if not self._mGotData:
-            if constants._debug:
+            if _debug:
                 sys.stderr.write('no data received!\n')
             return
         self.done = True
@@ -152,7 +154,7 @@ class UniversalDetector:
                                'confidence': maxProber.get_confidence()}
                 return self.result
 
-        if constants._debug:
+        if _debug:
             sys.stderr.write('no probers hit minimum threshhold\n')
             for prober in self._mCharSetProbers[0].mProbers:
                 if not prober: continue

--- a/chardet/utf8prober.py
+++ b/chardet/utf8prober.py
@@ -13,20 +13,17 @@
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
 # version 2.1 of the License, or (at your option) any later version.
-# 
+#
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
-
-from __future__ import absolute_import
-import sys
 
 from .constants import eStart, eError, eItsMe, eNotMe, eFoundIt, eDetecting, SHORTCUT_THRESHOLD
 from .charsetprober import CharSetProber
@@ -34,7 +31,9 @@ from .codingstatemachine import CodingStateMachine
 from .mbcssm import UTF8SMModel
 from six.moves import range
 
+
 ONE_CHAR_PROB = 0.5
+
 
 class UTF8Prober(CharSetProber):
     def __init__(self):

--- a/chardet/utf8prober.py
+++ b/chardet/utf8prober.py
@@ -25,11 +25,13 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
+from __future__ import absolute_import
 import constants, sys
-from constants import eStart, eError, eItsMe
-from charsetprober import CharSetProber
-from codingstatemachine import CodingStateMachine
-from mbcssm import UTF8SMModel
+from .constants import eStart, eError, eItsMe
+from .charsetprober import CharSetProber
+from .codingstatemachine import CodingStateMachine
+from .mbcssm import UTF8SMModel
+from six.moves import range
 
 ONE_CHAR_PROB = 0.5
 

--- a/chardet/utf8prober.py
+++ b/chardet/utf8prober.py
@@ -26,8 +26,9 @@
 ######################### END LICENSE BLOCK #########################
 
 from __future__ import absolute_import
-import constants, sys
-from .constants import eStart, eError, eItsMe
+import sys
+
+from .constants import eStart, eError, eItsMe, eNotMe, eFoundIt, eDetecting, SHORTCUT_THRESHOLD
 from .charsetprober import CharSetProber
 from .codingstatemachine import CodingStateMachine
 from .mbcssm import UTF8SMModel
@@ -53,18 +54,18 @@ class UTF8Prober(CharSetProber):
         for c in aBuf:
             codingState = self._mCodingSM.next_state(c)
             if codingState == eError:
-                self._mState = constants.eNotMe
+                self._mState = eNotMe
                 break
             elif codingState == eItsMe:
-                self._mState = constants.eFoundIt
+                self._mState = eFoundIt
                 break
             elif codingState == eStart:
                 if self._mCodingSM.get_current_charlen() >= 2:
                     self._mNumOfMBChar += 1
 
-        if self.get_state() == constants.eDetecting:
-            if self.get_confidence() > constants.SHORTCUT_THRESHOLD:
-                self._mState = constants.eFoundIt
+        if self.get_state() == eDetecting:
+            if self.get_confidence() > SHORTCUT_THRESHOLD:
+                self._mState = eFoundIt
 
         return self.get_state()
 


### PR DESCRIPTION
This PR includes changes needed to make `chardet==1.0.1` Python 3 compatible.